### PR TITLE
fix Dockerfile to use current repo for Facets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,10 @@ ADD . /facets-suite
 RUN cd /facets-suite && \
     Rscript -e "devtools::install()"
 ENV PATH=/facets-suite:$PATH
+
+# install Facets
+RUN wget https://github.com/mskcc/facets/archive/v0.5.14.zip -O facets_v0.5.14.zip && \
+    unzip facets_v0.5.14.zip && \
+    rm -f facets_v0.5.14.zip && \
+    cd facets-0.5.14 && \
+    Rscript -e "devtools::install()"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,9 @@ RUN cd /tmp \
 # Clean up tmp
 RUN rm -rf /tmp/*
 
-# Download facetsSuite repo
-RUN wget -O facets-suite-${FACETSSUITE_VERSION}.zip https://github.com/mskcc/facets-suite/archive/${FACETSSUITE_VERSION}.zip \
-    && unzip facets-suite-${FACETSSUITE_VERSION}.zip \
-    && mv facets-suite-${FACETSSUITE_VERSION}/*-wrapper.R /usr/bin \
-    && chmod +x /usr/bin/*wrapper.R
-
-# Install package
-RUN cd facets-suite-${FACETSSUITE_VERSION} \
-    && Rscript -e "devtools::install()"
-
-# Always run Rscript as vanilla
-RUN export Rscript="Rscript --vanilla"
+# Add Facets Suite to the container
+RUN mkdir /facets-suite
+ADD . /facets-suite
+RUN cd /facets-suite && \
+    Rscript -e "devtools::install()"
+ENV PATH=/facets-suite:$PATH


### PR DESCRIPTION
The Dockerfile was not working so I updated. The URL it was using is no longer valid and was giving these errors:

```
Step 11/13 : RUN wget -O facets-suite-${FACETSSUITE_VERSION}.zip https://github.com/mskcc/facets-suite/archive/${FACETSSUITE_VERSION}.zip     && unzip facets-suite-${FACETSSUITE_VERSION}.zip     && mv facets-suite-${FACETSSUITE_VERSION}/*-wrapper.R /usr/bin     && chmod +x /usr/bin/*wrapper.R
 ---> Running in 95fdb15f342b
--2020-06-18 21:07:18--  https://github.com/mskcc/facets-suite/archive/Rpackagev2.zip
Resolving github.com (github.com)... 140.82.113.3
Connecting to github.com (github.com)|140.82.113.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/mskcc/facets-suite/zip/Rpackagev2 [following]
--2020-06-18 21:07:19--  https://codeload.github.com/mskcc/facets-suite/zip/Rpackagev2
Resolving codeload.github.com (codeload.github.com)... 140.82.113.10
Connecting to codeload.github.com (codeload.github.com)|140.82.113.10|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-06-18 21:07:19 ERROR 404: Not Found.

The command '/bin/sh -c wget -O facets-suite-${FACETSSUITE_VERSION}.zip https://github.com/mskcc/facets-suite/archive/${FACETSSUITE_VERSION}.zip     && unzip facets-suite-${FACETSSUITE_VERSION}.zip     && mv facets-suite-${FACETSSUITE_VERSION}/*-wrapper.R /usr/bin     && chmod +x /usr/bin/*wrapper.R' returned a non-zero code: 8

```