### PR TITLE
Update annotate-maf-wrapper.R

### DIFF
--- a/annotate-maf-wrapper.R
+++ b/annotate-maf-wrapper.R
@@ -101,8 +101,8 @@ output_maf = rbindlist(output_maf)
 
 # Add back samples that were missing in sample map
 if (any(!maf$Tumor_Sample_Barcode %in% sample_map$sample)) {
-    output_maf = rbindlist(output_maf,
-                           maf[!which(maf$Tumor_Sample_Barcode %in% sample_map$sample), ],
+    output_maf = rbindlist(list(output_maf,
+                           maf[!which(maf$Tumor_Sample_Barcode %in% sample_map$sample), ]),
                            use.names = TRUE, fill = TRUE)
 }
 


### PR DESCRIPTION
rbindlist throws an error: Error in rbindlist(output_maf, maf[!which(maf$Tumor_Sample_Barcode %in%  : Input is data.table but should be a plain list of items to be stacked unless a list is passed