### PR TITLE
Update oncoKB base URL

### DIFF
--- a/data-raw/sysdata.R
+++ b/data-raw/sysdata.R
@@ -137,7 +137,7 @@ hg38 = tibble::tribble(
 )
 
 # Gene positions --------------------------------------------------------------------------------------------------
-tumor_suppressors = fromJSON(readLines('http://oncokb.org/api/v1/genes', warn = FALSE)) %>% 
+tumor_suppressors = fromJSON(readLines('https://legacy.oncokb.org/api/v1/genes', warn = FALSE)) %>% 
     filter(tsg == TRUE) %>% 
     select(hugoSymbol) %>% 
     mutate(hugoSymbol = mapvalues(hugoSymbol,


### PR DESCRIPTION
OncoKB team just updated oncokb.org to www.oncokb.org, making the below line of oncoKB base url not valid anymore.