### PR TITLE
Minor fix to annotate-maf-wrapper.R

### DIFF
--- a/annotate-maf-wrapper.R
+++ b/annotate-maf-wrapper.R
@@ -3,6 +3,7 @@ suppressPackageStartupMessages({
     library(argparse)
     library(data.table)
     library(facetsSuite)
+    library(dplyr)
 })
 
 args = commandArgs(TRUE)


### PR DESCRIPTION
When the legacy output is used for  `--facets-output` it throws below error because `dplyr` is not imported.

`Error in fread(cncf_txt_file) %>% select(chrom, seg, num.mark, nhet, cnlr.median,  :
  could not find function "%>%"
Calls: lapply -> FUN -> ccf_annotate_maf_legacy
Execution halted`
